### PR TITLE
exclude CommandStartBePlatform form test coverage count

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
                 <configuration>
                     <excludes>
                         <exclude>**/BatFileCreator.*</exclude>
+                        <exclude>**/CommandStartBePlatform.*</exclude>
                     </excludes>
                     <destFile>${project.basedir}/target/jacoco.exec</destFile>
                     <dataFile>${project.basedir}/target/jacoco.exec</dataFile>


### PR DESCRIPTION
 - add INTO excludes section OF jacoco plugin CommandStartBePlatform