### PR TITLE
BbinitApplicationTests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
                     <excludes>
                         <exclude>**/BatFileCreator.*</exclude>
                         <exclude>**/CommandStartBePlatform.*</exclude>
+                        <exclude>**/CommandCheckRequirements.*</exclude>
                     </excludes>
                     <destFile>${project.basedir}/target/jacoco.exec</destFile>
                     <dataFile>${project.basedir}/target/jacoco.exec</dataFile>

--- a/src/main/java/com/dankknightkh/bbinit/BbInitApplication.java
+++ b/src/main/java/com/dankknightkh/bbinit/BbInitApplication.java
@@ -9,6 +9,7 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
@@ -78,6 +79,6 @@ public class BbInitApplication implements CommandLineRunner {
     }
 
     private boolean isCommandValid(CommandLine cmd) {
-        return cmd.hasOption(COMMAND_ALIAS) && cmd.getOptionValue(COMMAND_ALIAS) != null && catalog.getCommandKeys().contains(cmd.getOptionValue(COMMAND_ALIAS));
+        return cmd.hasOption(COMMAND_ALIAS) && StringUtils.isNoneEmpty(cmd.getOptionValue(COMMAND_ALIAS)) && catalog.getCommandKeys().contains(cmd.getOptionValue(COMMAND_ALIAS));
     }
 }

--- a/src/test/java/com/dankknightkh/bbinit/BBInitApplicationTest.java
+++ b/src/test/java/com/dankknightkh/bbinit/BBInitApplicationTest.java
@@ -7,11 +7,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 @SpringBootTest(args={"-p=training", "-c=noCommand"})
-class BbinitApplicationTests {
+class BBInitApplicationTest {
 
-	@Test
-	void contextLoads() {
-		assertThat(true, is(true));
-	}
+    @Test
+    void contextLoads() {
+        assertThat(true, is(true));
+    }
 
 }

--- a/src/test/java/com/dankknightkh/bbinit/BbinitApplicationUnitTests.java
+++ b/src/test/java/com/dankknightkh/bbinit/BbinitApplicationUnitTests.java
@@ -1,0 +1,81 @@
+package com.dankknightkh.bbinit;
+
+import com.dankknightkh.bbinit.command.catalog.CommandCatalog;
+import com.dankknightkh.bbinit.command.impl.CommandNoSuchCommand;
+import com.dankknightkh.bbinit.command.impl.CommandStartBePlatform;
+import org.apache.commons.cli.ParseException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.Set;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class BbinitApplicationUnitTests {
+
+	private CommandCatalog commandCatalog;
+	private CommandNoSuchCommand noSuchCommand;
+
+	private BbInitApplication bbInitApplication;
+
+	@BeforeEach
+	void setUp() {
+		commandCatalog = mock(CommandCatalog.class);
+		noSuchCommand = mock(CommandNoSuchCommand.class);
+		bbInitApplication = new BbInitApplication(commandCatalog);
+	}
+
+	@Test
+	void run_app_with_training_option_and_valid_command() throws ParseException {
+		when(commandCatalog.getCommandKeys()).thenReturn(Set.of("noCommand"));
+		when(commandCatalog.getCommandByName("noCommand")).thenReturn(noSuchCommand);
+		String[] args = {"-p=training", "-c=noCommand"};
+
+		bbInitApplication.run(args);
+
+		verify(commandCatalog, times(1)).getCommandByName("noCommand");
+		verify(noSuchCommand, times(1)).executeCommand();
+	}
+
+	@Test
+	void run_app_with_not_valid_command() throws ParseException {
+		when(commandCatalog.getCommandKeys()).thenReturn(Set.of("noCommand"));
+		when(commandCatalog.getCommandByName("noCommand")).thenReturn(noSuchCommand);
+		String[] args = {"-c=invalidCommandValue"};
+
+		bbInitApplication.run(args);
+
+		verify(commandCatalog, times(1)).getCommandByName("noCommand");
+	}
+
+	@Test
+	void run_app_with_st_run_option() throws ParseException {
+		when(commandCatalog.getCommandKeys()).thenReturn(Set.of("noCommand"));
+		when(commandCatalog.getCommandByName("noCommand")).thenReturn(noSuchCommand);
+		CommandStartBePlatform commandStartBePlatform = mock(CommandStartBePlatform.class);
+		when(commandCatalog.getCommandByName("start")).thenReturn(commandStartBePlatform);
+		String[] args = {"-st"};
+
+		bbInitApplication.run(args);
+
+		verify(commandCatalog, times(1)).getCommandByName("noCommand");
+		verify(commandStartBePlatform, times(1)).executeCommand();
+	}
+
+	@Test
+	void run_app_with_null_value_for_command_option() throws ParseException {
+		when(commandCatalog.getCommandKeys()).thenReturn(Set.of("noCommand"));
+		when(commandCatalog.getCommandByName("noCommand")).thenReturn(noSuchCommand);
+		String[] args = {"-c="};
+
+		bbInitApplication.run(args);
+
+		verify(commandCatalog, times(1)).getCommandByName("noCommand");
+	}
+
+}


### PR DESCRIPTION
 - add tests for bb init application
 - exclude CommandCheckRequirements from test coverage
 - make isCommandValid check option value on emptiness and not for null